### PR TITLE
Directory methods fixes

### DIFF
--- a/webdav/client.py
+++ b/webdav/client.py
@@ -278,12 +278,8 @@ class Client(object):
                     href = resp.findtext("{DAV:}href")
                     urn = unquote(href)
 
-                    if path.endswith(Urn.separate):
-                        if path == urn or path[:-1] == urn:
-                            return True
-                    else:
-                        if path == urn:
-                            return True
+                    if path.rstrip(Urn.separate) == urn.rstrip(Urn.separate):
+                        return True
 
                 return False
 

--- a/webdav/client.py
+++ b/webdav/client.py
@@ -843,10 +843,7 @@ class Client(object):
                         path_with_sep = "{path}{sep}".format(path=path, sep=Urn.separate)
                         if not path == urn and not path_with_sep == urn:
                             continue
-                    type = resp.find(".//{DAV:}resourcetype")
-                    if type is None:
-                        raise MethodNotSupported(name="is_dir", server=self.webdav.hostname)
-                    dir_type = type.find("{DAV:}collection")
+                    dir_type = resp.find(".//{DAV:}resourcetype/{DAV:}collection")
 
                     return True if dir_type is not None else False
 


### PR DESCRIPTION
On our DAV server, two functions on directories failed:
1. `check()` returned `False` when passed dav.check('/path/to/mydir'), where mydir is a directory
2. `is_dir()` raised a `MethodNotSupported` error on files

Fixed these two issues by
1. removing trailing slashes from both the path and urn before comparing
2. looking for a resourcetype/collection directly, thus resources without a resource type will not fail but return false.

Could you please consider these changes for a next release?