### PR TITLE
Add support for query and matrix parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,89 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/webdav/client.py
+++ b/webdav/client.py
@@ -172,7 +172,7 @@ class Client(object):
 
         return curl
 
-    def list(self, remote_path=root):
+    def list(self, remote_path=root, matrix_params=None, query_params=None):
 
         def parse(response):
 
@@ -185,7 +185,11 @@ class Client(object):
                 return list()
 
         try:
-            directory_urn = Urn(remote_path, directory=True)
+            directory_urn = Urn(
+                remote_path,
+                directory=True,
+                matrix_params=matrix_params,
+                query_params=query_params)
 
             if directory_urn.path() != Client.root:
                 if not self.check(directory_urn.path()):
@@ -264,7 +268,7 @@ class Client(object):
         except pycurl.error:
             raise NotConnection(self.webdav.hostname)
 
-    def check(self, remote_path=root):
+    def check(self, remote_path=root, matrix_params=None, query_params=None):
 
         def parse(response, path):
 
@@ -291,8 +295,14 @@ class Client(object):
                 raise MethodNotSupported(name="check", server=self.webdav.hostname)
 
         try:
-            urn = Urn(remote_path)
-            parent_urn = Urn(urn.parent())
+            urn = Urn(remote_path, matrix_params=matrix_params, query_params=query_params)
+            matrix_params = matrix_params or {}
+            parent_matrix_params = matrix_params.copy()
+            parent_matrix_params.pop(remote_path, None)
+            parent_urn = Urn(
+                urn.parent(),
+                matrix_params=parent_matrix_params,
+                query_params=query_params)
             response = BytesIO()
 
             url = {'hostname': self.webdav.hostname, 'root': self.webdav.root, 'path': parent_urn.quote()}
@@ -339,10 +349,10 @@ class Client(object):
         except pycurl.error:
             raise NotConnection(self.webdav.hostname)
 
-    def download_to(self, buff, remote_path):
+    def download_to(self, buff, remote_path, matrix_params=None, query_params=None):
 
         try:
-            urn = Urn(remote_path)
+            urn = Urn(remote_path, matrix_params=matrix_params, query_params=query_params)
 
             if self.is_dir(urn.path()):
                 raise OptionNotValid(name="remote_path", value=remote_path)
@@ -391,10 +401,10 @@ class Client(object):
             _local_path = os.path.join(local_path, resource_name)
             self.download(local_path=_local_path, remote_path=_remote_path, progress=progress)
 
-    def download_file(self, remote_path, local_path, progress=None):
+    def download_file(self, remote_path, local_path, progress=None, matrix_params=None, query_params=None):
 
         try:
-            urn = Urn(remote_path)
+            urn = Urn(remote_path, matrix_params=matrix_params, query_params=query_params)
 
             if self.is_dir(urn.path()):
                 raise OptionNotValid(name="remote_path", value=remote_path)
@@ -439,10 +449,10 @@ class Client(object):
         target = (lambda: self.download_sync(local_path=local_path, remote_path=remote_path, callback=callback))
         threading.Thread(target=target).start()
 
-    def upload_from(self, buff, remote_path):
+    def upload_from(self, buff, remote_path, matrix_params=None, query_params=None):
 
         try:
-            urn = Urn(remote_path)
+            urn = Urn(remote_path, matrix_params=matrix_params, query_params=query_params)
 
             if urn.is_dir():
                 raise OptionNotValid(name="remote_path", value=remote_path)
@@ -500,13 +510,13 @@ class Client(object):
             _local_path = os.path.join(local_path, resource_name)
             self.upload(local_path=_local_path, remote_path=_remote_path, progress=progress)
 
-    def upload_file(self, remote_path, local_path, progress=None):
+    def upload_file(self, remote_path, local_path, progress=None, matrix_params=None, query_params=None):
 
         try:
             if not os.path.exists(local_path):
                 raise LocalResourceNotFound(local_path)
 
-            urn = Urn(remote_path)
+            urn = Urn(remote_path, matrix_params=matrix_params, query_params=query_params)
 
             if urn.is_dir():
                 raise OptionNotValid(name="remote_path", value=remote_path)
@@ -640,10 +650,10 @@ class Client(object):
         except pycurl.error:
             raise NotConnection(self.webdav.hostname)
 
-    def clean(self, remote_path):
+    def clean(self, remote_path, matrix_params=None, query_params=None):
 
         try:
-            urn = Urn(remote_path)
+            urn = Urn(remote_path, matrix_params=matrix_params, query_params=query_params)
 
             url = {'hostname': self.webdav.hostname, 'root': self.webdav.root, 'path': urn.quote()}
             options = {
@@ -756,7 +766,7 @@ class Client(object):
         except pycurl.error:
             raise NotConnection(self.webdav.hostname)
 
-    def info(self, remote_path):
+    def info(self, remote_path, matrix_params=None, query_params=None):
 
         def parse(response, path):
 
@@ -795,7 +805,7 @@ class Client(object):
                 raise MethodNotSupported(name="info", server=self.webdav.hostname)
 
         try:
-            urn = Urn(remote_path)
+            urn = Urn(remote_path, matrix_params=matrix_params, query_params=query_params)
             response = BytesIO()
 
             if not self.check(urn.path()) and not self.check(Urn(remote_path, directory=True).path()):
@@ -889,7 +899,7 @@ class Client(object):
         urn = Urn(remote_path)
         return Resource(self, urn.path())
 
-    def get_property(self, remote_path, option):
+    def get_property(self, remote_path, option, matrix_params=None, query_params=None):
 
         def parse(response, option):
 
@@ -911,7 +921,7 @@ class Client(object):
             return buff.getvalue()
 
         try:
-            urn = Urn(remote_path)
+            urn = Urn(remote_path, matrix_params=matrix_params, query_params=query_params)
 
             if not self.check(urn.path()):
                 raise RemoteResourceNotFound(urn.path())
@@ -938,7 +948,7 @@ class Client(object):
         except pycurl.error:
             raise NotConnection(self.webdav.hostname)
 
-    def set_property(self, remote_path, option):
+    def set_property(self, remote_path, option, matrix_params=None, query_params=None):
 
         def data(option):
 
@@ -957,7 +967,7 @@ class Client(object):
             return buff.getvalue()
 
         try:
-            urn = Urn(remote_path)
+            urn = Urn(remote_path, matrix_params=matrix_params, query_params=query_params)
 
             if not self.check(urn.path()):
                 raise RemoteResourceNotFound(urn.path())

--- a/webdav/params.py
+++ b/webdav/params.py
@@ -1,0 +1,40 @@
+"""Matrix parameter compiler."""
+
+try:
+    from urllib.parse import quote_plus
+except ImportError:
+    from urllib import quote_plus
+
+
+def quote_path_with_matrix_params(path, matrix_params):
+    """Compile a path and matrix parameter dict into a quoted URI path.
+
+    >>> quote_path_with_matrix_params("/~parent/folder/file.txt" ,
+    ...     {
+    ...         "/~parent": {"a": ["1;", "2!"]},
+    ...         "/~parent/folder/file.txt": {"i d": ["?"]},
+    ...     },
+    ... )
+    '/%7Eparent;a=1%3B;a=2%21/folder/file.txt;i+d=%3F'
+    """
+    matrix_params = matrix_params or {}
+
+    names = []
+    components = []
+    for name in path.split('/'):
+        names.append(name)
+        path_so_far = '/'.join(names)
+        try:
+            params = matrix_params[path_so_far]
+        except KeyError:
+            component = name
+        else:
+            path_params = []
+            for key, values in sorted(params.items()):
+                for value in values:
+                    path_params.append(
+                        ';{}={}'.format(quote_plus(key), quote_plus(value))
+                    )
+            component = '{}{}'.format(quote_plus(name), ''.join(path_params))
+        components.append(component)
+    return '/'.join(components)

--- a/webdav/urn.py
+++ b/webdav/urn.py
@@ -1,18 +1,19 @@
 try:
-    from urllib.parse import unquote, quote
+    from urllib.parse import unquote, urlencode
 except ImportError:
-    from urllib import unquote, quote
+    from urllib import unquote, urlencode
 
 from re import sub
+
+from webdav.params import quote_path_with_matrix_params
 
 
 class Urn(object):
 
     separate = "/"
 
-    def __init__(self, path, directory=False):
-
-        self._path = quote(path)
+    def __init__(self, path, directory=False, matrix_params=None, query_params=None):
+        self._path = path
         expressions = "/\.+/", "/+"
         for expression in expressions:
             self._path = sub(expression, Urn.separate, self._path)
@@ -23,6 +24,9 @@ class Urn(object):
         if directory and not self._path.endswith(Urn.separate):
             self._path = "{begin}{end}".format(begin=self._path, end=Urn.separate)
 
+        self.matrix_params = matrix_params
+        self.query_params = query_params
+
     def __str__(self):
         return self.path()
 
@@ -30,7 +34,10 @@ class Urn(object):
         return unquote(self._path)
 
     def quote(self):
-        return self._path
+        path = quote_path_with_matrix_params(self.path(), self.matrix_params)
+        if self.query_params:
+            return '{}?{}'.format(path, urlencode(self.query_params))
+        return path
 
     def filename(self):
 


### PR DESCRIPTION
We need the ability to add metadata to our WebDAV requests. Query parameters allow adding metadata on a per url basis, and matrix parameters allow this on a per path component (i.e. folder or file) basis.

This patch adds `query_params` and `matrix_params` arguments to the main WebDAV methods as well as the `Urn` class.

We've ensured that these parameters are not used when deciding if a certain path is present in a directory listing, but are present when making a quoted URN to be requested from the server.